### PR TITLE
Differentiate error conditions

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -25,10 +25,17 @@ if [ -f $ENV_DIR/PROJECT_PATH ]; then
 		echo "       cleaning tmp dir $TMP_DIR"
 		rm -rf $TMP_DIR
 		exit 0
+	else
+	echo "       PROJECT_PATH is defined but does not exist"
+	echo "       expected $BUILD_DIR to contain $PROJECT_PATH"
+	echo "       but it does not."
+	echo ""
+	echo "Contents of $BUILD_DIR:"
+	echo ""
+	ls -la $BUILD_DIR
+	exit 1
 	fi
+else
+	echo "       PROJECT_PATH is undefined"
+	exit 1
 fi
-
-echo "PROJECT_PATH is undefined"
-exit 1
-
-


### PR DESCRIPTION
When you commit to git with only one directory and nothing else in root, it will push the contents of just that directory. I.e. an app with this structure fails to deploy:

```
mkdir -p app
touch app/Gemfile
touch app/Gemfile.lock
git init .; git add . ; git commit -m "first"
```

The error message is `PROJECT_PATH is undefined` which is incorrect. I added another error message that would properly identify the failure mode and give you more debugging information.