### PR TITLE
Error if we're not the first buildpack

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -12,6 +12,18 @@ if [ -f $ENV_DIR/PROJECT_PATH ]; then
 	PROJECT_PATH=`cat $ENV_DIR/PROJECT_PATH`
 	if [ -d $BUILD_DIR/$PROJECT_PATH ]; then
 		echo "-----> Subdir buildpack in $PROJECT_PATH"
+
+		if [ -n "$(ls -A $BUILD_DIR/.profile.d 2>/dev/null)" ]; then
+			echo "       Another buildpack seems to have run"
+			echo "       before the subdir buildpack. This"
+			echo "       may cause unexpected problems."
+			echo ""
+			echo "       Ensure '$ heroku buildpacks' lists"
+			echo "       the subdir buildpack first and try"
+			echo "       again."
+			exit 1
+		fi
+
 		echo "       creating cache: $CACHE_DIR"
 		mkdir -p $CACHE_DIR
 		TMP_DIR=`mktemp -d $CACHE_DIR/subdirXXXXX`


### PR DESCRIPTION
I had someone using the `heroku/metrics` buildpack which writes to `.profile.d` directory running before this buildpack. Because this buildpack deletes everything at the root, including things from other build packs, the change was not preserved even though it looked like it executed correctly. 

I'm proposing if we detect that another buildpack has executed (i.e. if the `.profile.d` folder is not empty), that we abort and error with a helpful message:

```
[main 2446fe5] empty
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 185 bytes | 185.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0
remote: Compressing source files... done.
remote: Building source:
remote:
remote: -----> Building on the Heroku-20 stack
remote: -----> Using buildpacks:
remote:        1. heroku/metrics
remote:        2. https://github.com/schneems/subdir-heroku-buildpack#schneems/don-t-delete-profile-d
remote: -----> HerokuRuntimeMetrics app detected
remote: -----> Setting up .profile.d to automatically run metrics agent...
remote: -----> Subdir buildpack app detected
remote: -----> Subdir buildpack in api
remote:        Another buildpack seems to have run
remote:        before the subdir buildpack. This
remote:        may cause unexpected problems.
remote:
remote:        Ensure '$ heroku buildpacks' lists
remote:        the subdir buildpack first and try
remote:        again.
remote:  !     Push rejected, failed to compile Subdir buildpack app.
remote:
remote:  !     Push failed
remote: Verifying deploy...
remote:
remote: !	Push rejected to still-harbor-23981.
$ heroku buildpacks
=== still-harbor-23981 Buildpack URLs
1. heroku/metrics
2. https://github.com/schneems/subdir-heroku-buildpack#schneems/don-t-delete-profile-d
```